### PR TITLE
feat: determine exec / args for windows like CreateProcess does

### DIFF
--- a/autoruns_aix.go
+++ b/autoruns_aix.go
@@ -2,10 +2,6 @@
 
 package autoruns
 
-func parsePath(entryValue string) ([]string, error) {
-	return []string{}, nil
-}
-
 // This function just invokes all the platform-dependant functions.
 func getAutoruns() (records []*Autorun) {
 	return

--- a/autoruns_linux.go
+++ b/autoruns_linux.go
@@ -2,10 +2,6 @@
 
 package autoruns
 
-func parsePath(entryValue string) ([]string, error) {
-	return []string{}, nil
-}
-
 // This function just invokes all the platform-dependant functions.
 func getAutoruns() (records []*Autorun) {
 	return


### PR DESCRIPTION
go-shellwords parses some features that are not really usable like
that on Windows. Also, unquoted executables (which can be passed
to CreateProcess) are not parsed correctly so far.
Therefore, the CreateProcess logic is instead rewritten in Golang
for resolving the executable based on a command line.